### PR TITLE
Add support for non-`*.app` executables.

### DIFF
--- a/Fluor.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Fluor.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Fluor/BehaviorController.swift
+++ b/Fluor/BehaviorController.swift
@@ -35,7 +35,7 @@ class BehaviorController: NSObject, BehaviorDidChangeHandler, DefaultModeViewCon
         NSWorkspace.shared.notificationCenter.addObserver(self, selector: #selector(sessionDidBecomeActive(notification:)), name: NSWorkspace.sessionDidBecomeActiveNotification, object: nil)
         
         guard !BehaviorManager.default.isDisabled() else { return }
-        if let currentApp = NSWorkspace.shared.frontmostApplication, let id = currentApp.bundleIdentifier {
+        if let currentApp = NSWorkspace.shared.frontmostApplication, let id = currentApp.bundleIdentifier ?? currentApp.executableURL?.lastPathComponent {
             adaptModeForApp(withId: id)
             updateAppBehaviorViewFor(app: currentApp, id: id)
         }
@@ -103,7 +103,7 @@ class BehaviorController: NSObject, BehaviorDidChangeHandler, DefaultModeViewCon
     /// - parameter notification: The notification.
     @objc private func activeAppDidChange(notification: Notification) {
         guard let app = notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication,
-            let id = app.bundleIdentifier else { return }
+            let id = app.bundleIdentifier ?? app.executableURL?.lastPathComponent else { return }
         currentID = id
         updateAppBehaviorViewFor(app: app, id: id)
         if !BehaviorManager.default.isDisabled() {

--- a/Fluor/CurrentAppViewController.swift
+++ b/Fluor/CurrentAppViewController.swift
@@ -14,8 +14,8 @@ class CurrentAppViewController: NSViewController {
         let bundleURL: URL?
         
         init(from app: NSRunningApplication) {
-            self.bundleIdentifier = app.bundleIdentifier
-            self.bundleURL = app.bundleURL
+            self.bundleIdentifier = app.bundleIdentifier ?? app.executableURL?.lastPathComponent
+            self.bundleURL = app.bundleURL ?? app.executableURL
         }
     }
     

--- a/Fluor/Info.plist
+++ b/Fluor/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.2beta</string>
 	<key>CFBundleVersion</key>
-	<string>615</string>
+	<string>640</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.productivity</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Fluor/RunningAppsWindowController.swift
+++ b/Fluor/RunningAppsWindowController.swift
@@ -47,8 +47,8 @@ class RunningAppsWindowController: NSWindowController, NSTableViewDelegate, Beha
     /// - parameter notification: The notification.
     @objc private func appDidLaunch(notification: Notification) {
         guard let app = notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication,
-            let appId = app.bundleIdentifier,
-            let appURL = app.bundleURL,
+            let appId = app.bundleIdentifier ?? app.executableURL?.lastPathComponent,
+            let appURL = app.bundleURL ?? app.executableURL,
             let appIcon = app.icon else { return }
         let appPath = appURL.path
         let appName = Bundle(path: appPath)?.localizedInfoDictionary?["CFBundleName"] as? String ?? appURL.deletingPathExtension().lastPathComponent
@@ -63,7 +63,7 @@ class RunningAppsWindowController: NSWindowController, NSTableViewDelegate, Beha
     /// - parameter notification: The notification.
     @objc private func appDidTerminate(notification: Notification) {
         guard let app = notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication,
-            let appId = app.bundleIdentifier,
+            let appId = app.bundleIdentifier ?? app.executableURL?.lastPathComponent,
             let index = runningAppsArray.index(where: { $0.id == appId }) else { return }
         runningAppsArray.remove(at: index)
     }
@@ -78,7 +78,7 @@ class RunningAppsWindowController: NSWindowController, NSTableViewDelegate, Beha
     /// Load all running applications and populate the table view with corresponding datas.
     private func loadData() {
         runningAppsArray = NSWorkspace.shared.runningApplications.flatMap { (app) -> RuleItem? in
-            guard let appId = app.bundleIdentifier, let appURL = app.bundleURL, let appIcon = app.icon else { return nil }
+            guard let appId = app.bundleIdentifier ?? app.executableURL?.lastPathComponent, let appURL = app.bundleURL ?? app.executableURL, let appIcon = app.icon else { return nil }
             let isApp = app.activationPolicy == .regular
             guard showAll || isApp else { return nil }
             let appPath = appURL.path


### PR DESCRIPTION
This adds support for programs which aren't `*.app` bundles. Some games are not full `*.app` bundles, for example and will run directly from an executable. In this case, use the executable name as the `id` and the executable path as the `appURL`.

Probably fixes https://github.com/Pyroh/Fluor/issues/21, since I assume the Wine wrapper runs the contained executable directly.

---

PS: I couldn't compile the project at first because some icons are missing, I had to comment them out for it to compile.