### PR TITLE
Fix build issues, crashes, and Rules Editor remove button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ fastlane/screenshots
 Documentation/docs
 /Fluor/Sparkle.framework
 /Fluor/Sparkle.framework.dSYM
+.DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,8 +60,14 @@ Bridged via `Fluor-Bridging-Header.h`:
 ### SPM Dependencies
 
 - **DefaultsWrapper** — `@Defaults` property wrapper for typed UserDefaults access
-- **Sparkle** (v2.x) — auto-update framework (`SPUStandardUpdaterController` in Preferences.storyboard)
+- **Sparkle** (v2.x) — auto-update framework (bindings go through `self.updater.*` key paths in Preferences.storyboard)
 - **CoreGeometry** / **SmoothOperators** — geometry utilities and operator extensions
+
+## Gotchas
+
+- **KVO + `@objc let` properties**: Storyboard bindings using nested key paths through `@objc let` stored properties (e.g., `objectValue.url.path` where `url` is `let`) crash on modern macOS — KVO can't create an ivar setter for constants. Use a `@objc dynamic var` computed wrapper instead, or avoid nested paths through `let` properties.
+- **Window display pattern**: Use `makeKeyAndOrderFront(self)` + `makeMain()` + `NSApp.activate(ignoringOtherApps:)` to show windows. Do not use `orderFrontRegardless()`.
+- **Storyboard debugging**: When investigating storyboard-related crashes, always request the crash backtrace — code review alone is insufficient for KVO/binding issues.
 
 ## Commit Guidelines
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+## Commit Guidelines
+
+- Do not include "Co-Authored-By" lines or any Claude/AI attribution in commit messages.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,68 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build Commands
+
+```bash
+# Build (requires Xcode; use DEVELOPER_DIR if xcode-select points to CommandLineTools)
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -scheme Fluor -configuration Debug build
+
+# Build without code signing (for development without matching certificates)
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -scheme Fluor -configuration Debug build CODE_SIGN_IDENTITY="-" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+```
+
+There are no tests in this project. The project uses Xcode (not Swift Package Manager) as its build system.
+
+## Architecture
+
+Fluor is a macOS status bar app (Swift 5 / AppKit) that switches the keyboard's fn-key behavior (media keys vs F1-F12) based on the active application.
+
+### Core Flow
+
+```
+AppDelegate → StatusMenuController (status bar item, Main.xib)
+                ├── BehaviorController     — monitors active app, switches fn-key mode via FKeyManager
+                ├── MenuItemsController    — manages menu UI (embeds 3 child ViewControllers)
+                └── Window Controllers     — lazy-loaded via StoryboardInstantiable protocol
+                    ├── PreferencesWindowController  (Preferences.storyboard)
+                    ├── RulesEditorWindowController  (RulesEditor.storyboard)
+                    ├── RunningAppWindowController   (RunningApps.storyboard)
+                    └── AboutWindowController        (About.storyboard)
+```
+
+### Key Components
+
+- **FKeyManager** (`Misc/FKeyManager.swift`) — IOKit interface that reads/writes the fn-key mode via `IOHIDSetCFTypeParameter` and `IORegistryEntryCreateCFProperty`. Requires Accessibility permissions.
+- **BehaviorController** (`Controllers/BehaviorController.swift`) — Core logic: listens to NSWorkspace active-app changes, determines target FKeyMode from stored rules, and calls FKeyManager. Also handles Fn-key press detection for hybrid/key switch methods.
+- **AppManager** (`Models/AppManager.swift`) — Singleton storing all persistent state via `@Defaults` property wrappers (from DefaultsWrapper SPM package). Holds the rule set, default mode, switch method, UI preferences.
+- **StatusMenuController** (`Controllers/StatusMenuController.swift`) — Owns the NSStatusItem, delegates to BehaviorController and MenuItemsController, manages window controller lifecycle.
+
+### Communication Pattern
+
+Components communicate via paired Notification observer/poster protocols defined in `Protocols/NotificationHelpers.swift`:
+- `BehaviorDidChange` — fn-key behavior changed for an app
+- `SwitchMethodDidChange` — user changed switch method (window/hybrid/key)
+- `MenuControlObserver/Poster` — menu open/close coordination
+
+### Three Switch Methods (enum `SwitchMethod`)
+
+1. **Window** — auto-switch based on frontmost app's stored rule
+2. **Hybrid** — window mode + Fn-key press toggles current app's behavior
+3. **Key** — Fn-key press toggles global default mode only
+
+### Objective-C Interop
+
+Bridged via `Fluor-Bridging-Header.h`:
+- **LaunchAtLoginController** — manages login item registration
+- **PFMoveApplication** — prompts to move app to /Applications (RELEASE builds only)
+
+### SPM Dependencies
+
+- **DefaultsWrapper** — `@Defaults` property wrapper for typed UserDefaults access
+- **Sparkle** (v2.x) — auto-update framework (`SPUStandardUpdaterController` in Preferences.storyboard)
+- **CoreGeometry** / **SmoothOperators** — geometry utilities and operator extensions
+
 ## Commit Guidelines
 
 - Do not include "Co-Authored-By" lines or any Claude/AI attribution in commit messages.

--- a/Fluor.xcodeproj/project.pbxproj
+++ b/Fluor.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -42,8 +42,7 @@
 		3F8F93BB1EEAC9B900FCE91F /* RuleCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8F93BA1EEAC9B900FCE91F /* RuleCellView.swift */; };
 		3F8F93BD1EEAF1EB00FCE91F /* RuleValueTransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8F93BC1EEAF1EB00FCE91F /* RuleValueTransformer.swift */; };
 		3F9EDD2A245C7BAF0047D1AC /* MenuItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F9EDD29245C7BAF0047D1AC /* MenuItemView.swift */; };
-		3FBE4C262222A3C600782647 /* Sparkle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FBE4C202222A22200782647 /* Sparkle.framework */; };
-		3FBE4C272222A3C600782647 /* Sparkle.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3FBE4C202222A22200782647 /* Sparkle.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		3FBE4C262222A3C600782647 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 3FBE4C302222A3C600782647 /* Sparkle */; };
 		3FBE4C292222AB0200782647 /* dsa_pub.pem in Resources */ = {isa = PBXBuildFile; fileRef = 3FBE4C282222AB0200782647 /* dsa_pub.pem */; };
 		3FC44EFA1D7F169A0065D433 /* Enums.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FC44EF91D7F169A0065D433 /* Enums.swift */; };
 		3FC44EFC1D7F16CB0065D433 /* Items.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FC44EFB1D7F16CB0065D433 /* Items.swift */; };
@@ -67,20 +66,6 @@
 		3FF2410B1EDB4E0000E524CD /* SwitchMethodViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FF2410A1EDB4E0000E524CD /* SwitchMethodViewController.swift */; };
 		3FF655CA20751D1600C8D2FC /* PFMoveApplication.m in Sources */ = {isa = PBXBuildFile; fileRef = 3FF655C820751D1600C8D2FC /* PFMoveApplication.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 /* End PBXBuildFile section */
-
-/* Begin PBXCopyFilesBuildPhase section */
-		3FBE4C252222A25200782647 /* Embed Frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				3FBE4C272222A3C600782647 /* Sparkle.framework in Embed Frameworks */,
-			);
-			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		3DF3612324C206AD00231BF5 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/MainMenu.strings"; sourceTree = "<group>"; };
@@ -126,7 +111,6 @@
 		3F8F93BA1EEAC9B900FCE91F /* RuleCellView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RuleCellView.swift; sourceTree = "<group>"; };
 		3F8F93BC1EEAF1EB00FCE91F /* RuleValueTransformer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RuleValueTransformer.swift; sourceTree = "<group>"; };
 		3F9EDD29245C7BAF0047D1AC /* MenuItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuItemView.swift; sourceTree = "<group>"; };
-		3FBE4C202222A22200782647 /* Sparkle.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Sparkle.framework; path = ../../../../pyroh/Dev/Projects/Fluor/Fluor/Sparkle.framework; sourceTree = "<group>"; };
 		3FBE4C282222AB0200782647 /* dsa_pub.pem */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = dsa_pub.pem; sourceTree = "<group>"; };
 		3FC44EF91D7F169A0065D433 /* Enums.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Enums.swift; sourceTree = "<group>"; };
 		3FC44EFB1D7F16CB0065D433 /* Items.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Items.swift; sourceTree = "<group>"; };
@@ -165,7 +149,7 @@
 			files = (
 				3FE7B6DB245DF8450027DB39 /* SmoothOperators in Frameworks */,
 				3F16ECDD23E9D1AC008BC89A /* DefaultsWrapper in Frameworks */,
-				3FBE4C262222A3C600782647 /* Sparkle.framework in Frameworks */,
+				3FBE4C262222A3C600782647 /* Sparkle in Frameworks */,
 				3F15629F23FEDD0000CD0773 /* CoreGeometry in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -279,7 +263,6 @@
 		3F7291EC2025BD1E005C9B70 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				3FBE4C202222A22200782647 /* Sparkle.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -347,7 +330,6 @@
 				3FCD169E1D79793600C57B22 /* Frameworks */,
 				3FCD169F1D79793600C57B22 /* Resources */,
 				3FD11B2F207A320800742415 /* Run Script */,
-				3FBE4C252222A25200782647 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -358,6 +340,7 @@
 				3F16ECDC23E9D1AC008BC89A /* DefaultsWrapper */,
 				3F15629E23FEDD0000CD0773 /* CoreGeometry */,
 				3FE7B6DA245DF8450027DB39 /* SmoothOperators */,
+				3FBE4C302222A3C600782647 /* Sparkle */,
 			);
 			productName = Fluor;
 			productReference = 3FCD16A11D79793600C57B22 /* Fluor.app */;
@@ -403,6 +386,7 @@
 				3F16ECDB23E9D1AC008BC89A /* XCRemoteSwiftPackageReference "DefaultsWrapper" */,
 				3F15629D23FEDD0000CD0773 /* XCRemoteSwiftPackageReference "CoreGeometry" */,
 				3FE7B6D9245DF8450027DB39 /* XCRemoteSwiftPackageReference "SmoothOperators" */,
+				3FBE4C2F2222A3C600782647 /* XCRemoteSwiftPackageReference "Sparkle" */,
 			);
 			productRefGroup = 3FCD16A21D79793600C57B22 /* Products */;
 			projectDirPath = "";
@@ -626,7 +610,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
@@ -680,7 +664,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -699,18 +683,15 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 5;
-				DEVELOPMENT_TEAM = Q2E884V952;
+				DEVELOPMENT_TEAM = 87NLB3L2H3;
 				ENABLE_HARDENED_RUNTIME = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Fluor",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Fluor/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MARKETING_VERSION = 2.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.pyrolyse.Fluor;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -733,18 +714,15 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 5;
-				DEVELOPMENT_TEAM = Q2E884V952;
+				DEVELOPMENT_TEAM = 87NLB3L2H3;
 				ENABLE_HARDENED_RUNTIME = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Fluor",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Fluor/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MARKETING_VERSION = 2.5.0;
 				OTHER_SWIFT_FLAGS = "-DRELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = com.pyrolyse.Fluor;
@@ -798,6 +776,14 @@
 				minimumVersion = 1.1.0;
 			};
 		};
+		3FBE4C2F2222A3C600782647 /* XCRemoteSwiftPackageReference "Sparkle" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/sparkle-project/Sparkle.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.0.0;
+			};
+		};
 		3FE7B6D9245DF8450027DB39 /* XCRemoteSwiftPackageReference "SmoothOperators" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Pyroh/SmoothOperators.git";
@@ -818,6 +804,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 3F16ECDB23E9D1AC008BC89A /* XCRemoteSwiftPackageReference "DefaultsWrapper" */;
 			productName = DefaultsWrapper;
+		};
+		3FBE4C302222A3C600782647 /* Sparkle */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3FBE4C2F2222A3C600782647 /* XCRemoteSwiftPackageReference "Sparkle" */;
+			productName = Sparkle;
 		};
 		3FE7B6DA245DF8450027DB39 /* SmoothOperators */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Fluor.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Fluor.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,34 +1,33 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "CoreGeometry",
-        "repositoryURL": "https://gitlab.com/Pyroh/CoreGeometry.git",
-        "state": {
-          "branch": null,
-          "revision": "a59affa331972263980f8a2af4cfd5f37ad42d3d",
-          "version": "3.0.0"
-        }
-      },
-      {
-        "package": "DefaultsWrapper",
-        "repositoryURL": "https://github.com/Pyroh/DefaultsWrapper.git",
-        "state": {
-          "branch": null,
-          "revision": "649794e5c7af45f69d1e128a3c9fd0fe1cde282e",
-          "version": "1.2.0"
-        }
-      },
-      {
-        "package": "SmoothOperators",
-        "repositoryURL": "https://github.com/Pyroh/SmoothOperators.git",
-        "state": {
-          "branch": null,
-          "revision": "12f0d7cc9ade6bc826a822f9d2021b4dd394c4a0",
-          "version": "0.4.0"
-        }
+  "originHash" : "9909bd4fc9f9e45ce69ffb584bbdae406c0443cc9c25d1bfec2bed3fe9bdb5e9",
+  "pins" : [
+    {
+      "identity" : "coregeometry",
+      "kind" : "remoteSourceControl",
+      "location" : "https://gitlab.com/Pyroh/CoreGeometry.git",
+      "state" : {
+        "revision" : "a59affa331972263980f8a2af4cfd5f37ad42d3d",
+        "version" : "3.0.0"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "defaultswrapper",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Pyroh/DefaultsWrapper.git",
+      "state" : {
+        "revision" : "649794e5c7af45f69d1e128a3c9fd0fe1cde282e",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "smoothoperators",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Pyroh/SmoothOperators.git",
+      "state" : {
+        "revision" : "12f0d7cc9ade6bc826a822f9d2021b4dd394c4a0",
+        "version" : "0.4.0"
+      }
+    }
+  ],
+  "version" : 3
 }

--- a/Fluor.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Fluor.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,34 +1,42 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "CoreGeometry",
-        "repositoryURL": "https://gitlab.com/Pyroh/CoreGeometry.git",
-        "state": {
-          "branch": null,
-          "revision": "a59affa331972263980f8a2af4cfd5f37ad42d3d",
-          "version": "3.0.0"
-        }
-      },
-      {
-        "package": "DefaultsWrapper",
-        "repositoryURL": "https://github.com/Pyroh/DefaultsWrapper.git",
-        "state": {
-          "branch": null,
-          "revision": "649794e5c7af45f69d1e128a3c9fd0fe1cde282e",
-          "version": "1.2.0"
-        }
-      },
-      {
-        "package": "SmoothOperators",
-        "repositoryURL": "https://github.com/Pyroh/SmoothOperators.git",
-        "state": {
-          "branch": null,
-          "revision": "12f0d7cc9ade6bc826a822f9d2021b4dd394c4a0",
-          "version": "0.4.0"
-        }
+  "originHash" : "df83e47aff8db5afda649e64a1bb32af88bfc9a2ea94edfe3589bf4f1478a06f",
+  "pins" : [
+    {
+      "identity" : "coregeometry",
+      "kind" : "remoteSourceControl",
+      "location" : "https://gitlab.com/Pyroh/CoreGeometry.git",
+      "state" : {
+        "revision" : "a59affa331972263980f8a2af4cfd5f37ad42d3d",
+        "version" : "3.0.0"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "defaultswrapper",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Pyroh/DefaultsWrapper.git",
+      "state" : {
+        "revision" : "649794e5c7af45f69d1e128a3c9fd0fe1cde282e",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "smoothoperators",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Pyroh/SmoothOperators.git",
+      "state" : {
+        "revision" : "12f0d7cc9ade6bc826a822f9d2021b4dd394c4a0",
+        "version" : "0.4.0"
+      }
+    },
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle.git",
+      "state" : {
+        "revision" : "21d8df80440b1ca3b65fa82e40782f1e5a9e6ba2",
+        "version" : "2.9.0"
+      }
+    }
+  ],
+  "version" : 3
 }

--- a/Fluor.xcodeproj/xcshareddata/xcschemes/Fluor.xcscheme
+++ b/Fluor.xcodeproj/xcshareddata/xcschemes/Fluor.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "0930"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/Fluor.xcodeproj/xcshareddata/xcschemes/Fluor.xcscheme
+++ b/Fluor.xcodeproj/xcshareddata/xcschemes/Fluor.xcscheme
@@ -5,24 +5,6 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
-      <PreActions>
-         <ExecutionAction
-            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
-            <ActionContent
-               title = "Run Script"
-               scriptText = "">
-               <EnvironmentBuildable>
-                  <BuildableReference
-                     BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "3FCD16A01D79793600C57B22"
-                     BuildableName = "Fluor.app"
-                     BlueprintName = "Fluor"
-                     ReferencedContainer = "container:Fluor.xcodeproj">
-                  </BuildableReference>
-               </EnvironmentBuildable>
-            </ActionContent>
-         </ExecutionAction>
-      </PreActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -109,23 +91,5 @@
    <ArchiveAction
       buildConfiguration = "Release"
       revealArchiveInOrganizer = "YES">
-      <PostActions>
-         <ExecutionAction
-            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
-            <ActionContent
-               title = "Run Script"
-               scriptText = "">
-               <EnvironmentBuildable>
-                  <BuildableReference
-                     BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "3FCD16A01D79793600C57B22"
-                     BuildableName = "Fluor.app"
-                     BlueprintName = "Fluor"
-                     ReferencedContainer = "container:Fluor.xcodeproj">
-                  </BuildableReference>
-               </EnvironmentBuildable>
-            </ActionContent>
-         </ExecutionAction>
-      </PostActions>
    </ArchiveAction>
 </Scheme>

--- a/Fluor/Base.lproj/Preferences.storyboard
+++ b/Fluor/Base.lproj/Preferences.storyboard
@@ -220,7 +220,6 @@
                 </viewController>
                 <customObject id="xpC-Av-Pb6" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
                 <customObject id="eCo-0m-X2M" customClass="LaunchAtLoginController"/>
-                <customObject id="YAM-vM-LLT" customClass="SPUStandardUpdaterController"/>
                 <userDefaultsController representsSharedInstance="YES" id="XlE-y8-iHG"/>
             </objects>
             <point key="canvasLocation" x="772" y="96"/>
@@ -420,7 +419,7 @@
                                             <font key="font" metaFont="system"/>
                                         </buttonCell>
                                         <connections>
-                                            <binding destination="AeM-5q-gZ3" name="value" keyPath="self.automaticallyChecksForUpdates" id="zrL-1G-Aec"/>
+                                            <binding destination="AeM-5q-gZ3" name="value" keyPath="self.updater.automaticallyChecksForUpdates" id="zrL-1G-Aec"/>
                                         </connections>
                                     </button>
                                     <stackView distribution="fill" orientation="horizontal" alignment="top" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="750" verticalHuggingPriority="750" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="18z-fd-v5J">
@@ -433,7 +432,7 @@
                                                     <font key="font" metaFont="system"/>
                                                 </buttonCell>
                                                 <connections>
-                                                    <binding destination="AeM-5q-gZ3" name="value" keyPath="self.automaticallyDownloadsUpdates" id="FMx-vj-v0Z"/>
+                                                    <binding destination="AeM-5q-gZ3" name="value" keyPath="self.updater.automaticallyDownloadsUpdates" id="FMx-vj-v0Z"/>
                                                 </connections>
                                             </button>
                                         </subviews>
@@ -470,7 +469,7 @@
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
                                                         <connections>
-                                                            <binding destination="AeM-5q-gZ3" name="value" keyPath="self.lastUpdateCheckDate" id="oRH-3d-Kq9"/>
+                                                            <binding destination="AeM-5q-gZ3" name="value" keyPath="self.updater.lastUpdateCheckDate" id="oRH-3d-Kq9"/>
                                                         </connections>
                                                     </textField>
                                                 </subviews>

--- a/Fluor/Base.lproj/Preferences.storyboard
+++ b/Fluor/Base.lproj/Preferences.storyboard
@@ -220,7 +220,7 @@
                 </viewController>
                 <customObject id="xpC-Av-Pb6" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
                 <customObject id="eCo-0m-X2M" customClass="LaunchAtLoginController"/>
-                <customObject id="YAM-vM-LLT" customClass="SUUpdater"/>
+                <customObject id="YAM-vM-LLT" customClass="SPUStandardUpdaterController"/>
                 <userDefaultsController representsSharedInstance="YES" id="XlE-y8-iHG"/>
             </objects>
             <point key="canvasLocation" x="772" y="96"/>
@@ -532,7 +532,7 @@
                     </view>
                 </viewController>
                 <customObject id="uno-mT-3BM" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
-                <customObject id="AeM-5q-gZ3" customClass="SUUpdater"/>
+                <customObject id="AeM-5q-gZ3" customClass="SPUStandardUpdaterController"/>
             </objects>
             <point key="canvasLocation" x="772" y="783"/>
         </scene>

--- a/Fluor/Base.lproj/RulesEditor.storyboard
+++ b/Fluor/Base.lproj/RulesEditor.storyboard
@@ -10,7 +10,7 @@
         <scene sceneID="Ixx-p7-6Qw">
             <objects>
                 <windowController showSeguePresentationStyle="single" id="W33-Be-Q5Y" customClass="RulesEditorWindowController" customModule="Fluor" customModuleProvider="target" sceneMemberID="viewController">
-                    <window key="window" title="Rules" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="Fluor_EditRulesWindowAutosaveName" animationBehavior="default" id="eXk-yp-Np1" customClass="NSPanel">
+                    <window key="window" title="Rules" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="Fluor_EditRulesWindowAutosaveName" animationBehavior="default" id="eXk-yp-Np1">
                         <windowStyleMask key="styleMask" titled="YES" closable="YES" resizable="YES" fullSizeContentView="YES"/>
                         <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
                         <rect key="contentRect" x="196" y="240" width="320" height="480"/>
@@ -104,7 +104,6 @@
                                                                             <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyUpOrDown" image="NSApplicationIcon" id="2Fc-hq-NCR"/>
                                                                             <connections>
                                                                                 <binding destination="Kqn-bd-jZp" name="value" keyPath="objectValue.icon" id="WuV-6R-C9q"/>
-                                                                                <binding destination="Kqn-bd-jZp" name="toolTip" keyPath="objectValue.url.path" id="anr-Hc-yQM"/>
                                                                             </connections>
                                                                         </imageView>
                                                                         <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="agd-lq-cct">
@@ -173,9 +172,6 @@
                                                     </prototypeCellViews>
                                                 </tableColumn>
                                             </tableColumns>
-                                            <connections>
-                                                <binding destination="yyu-qn-zGG" name="selectionIndexes" keyPath="selectionIndexes" id="uAd-Ml-lCd"/>
-                                            </connections>
                                         </tableView>
                                     </subviews>
                                     <nil key="backgroundColor"/>

--- a/Fluor/Base.lproj/RunningApps.storyboard
+++ b/Fluor/Base.lproj/RunningApps.storyboard
@@ -10,7 +10,7 @@
         <scene sceneID="8tp-0P-yc1">
             <objects>
                 <windowController showSeguePresentationStyle="single" id="GhL-73-3vr" customClass="RunningAppWindowController" customModule="Fluor" customModuleProvider="target" sceneMemberID="viewController">
-                    <window key="window" title="Running Applications" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="Fluor_RunningAppsWindowAutosaveName" animationBehavior="default" id="Vdh-R9-Luc" customClass="NSPanel">
+                    <window key="window" title="Running Applications" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="Fluor_RunningAppsWindowAutosaveName" animationBehavior="default" id="Vdh-R9-Luc">
                         <windowStyleMask key="styleMask" titled="YES" closable="YES" resizable="YES" fullSizeContentView="YES"/>
                         <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
                         <rect key="contentRect" x="312" y="145" width="320" height="480"/>

--- a/Fluor/Controllers/StatusMenuController.swift
+++ b/Fluor/Controllers/StatusMenuController.swift
@@ -137,12 +137,16 @@ class StatusMenuController: NSObject, NSMenuDelegate, NSWindowDelegate, MenuCont
     /// - parameter sender: The object that sent the action.
     @IBAction func editRules(_ sender: AnyObject) {
         guard rulesController == nil else {
-            rulesController?.window?.orderFrontRegardless()
+            rulesController?.window?.makeKeyAndOrderFront(self)
+            rulesController?.window?.makeMain()
+            NSApp.activate(ignoringOtherApps: true)
             return
         }
         rulesController = RulesEditorWindowController.instantiate()
         rulesController?.window?.delegate = self
-        rulesController?.window?.orderFrontRegardless()
+        rulesController?.window?.makeKeyAndOrderFront(self)
+        rulesController?.window?.makeMain()
+        NSApp.activate(ignoringOtherApps: true)
     }
     
     /// Show the *About* window.
@@ -184,12 +188,16 @@ class StatusMenuController: NSObject, NSMenuDelegate, NSWindowDelegate, MenuCont
     /// - parameter sender: The object that sent the action.
     @IBAction func showRunningApps(_ sender: AnyObject) {
         guard runningAppsController == nil else {
-            runningAppsController?.window?.orderFrontRegardless()
+            runningAppsController?.window?.makeKeyAndOrderFront(self)
+            runningAppsController?.window?.makeMain()
+            NSApp.activate(ignoringOtherApps: true)
             return
         }
         runningAppsController = RunningAppWindowController.instantiate()
         runningAppsController?.window?.delegate = self
-        runningAppsController?.window?.orderFrontRegardless()
+        runningAppsController?.window?.makeKeyAndOrderFront(self)
+        runningAppsController?.window?.makeMain()
+        NSApp.activate(ignoringOtherApps: true)
     }
     
     

--- a/Fluor/Controllers/ViewControllers/RulesEditorViewController.swift
+++ b/Fluor/Controllers/ViewControllers/RulesEditorViewController.swift
@@ -50,10 +50,13 @@ class RulesEditorViewController: NSViewController, BehaviorDidChangeObserver {
         
         self.rulesSet = AppManager.default.rules
         
+        tableView.bind(.selectionIndexes, to: itemsArrayController!, withKeyPath: "selectionIndexes", options: nil)
+
         self.tableContentAnimator = TableViewContentAnimator(tableView: tableView, arrayController: itemsArrayController)
     }
-    
+
     deinit {
+        tableView.unbind(.selectionIndexes)
         stopObservingBehaviorDidChange()
         itemsArrayController.removeObserver(self, forKeyPath: "canRemove")
         itemsArrayController.removeObserver(self, forKeyPath: "canAdd")

--- a/Fluor/Info.plist
+++ b/Fluor/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>2345</string>
+	<string>2347</string>
 	<key>FLGithubURL</key>
 	<string>https://github.com/Pyroh/Fluor</string>
 	<key>FLPyrolyseURL</key>

--- a/Fluor/Info.plist
+++ b/Fluor/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>2373</string>
+	<string>2374</string>
 	<key>FLGithubURL</key>
 	<string>https://github.com/Pyroh/Fluor</string>
 	<key>FLPyrolyseURL</key>

--- a/Fluor/Info.plist
+++ b/Fluor/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>2371</string>
+	<string>2373</string>
 	<key>FLGithubURL</key>
 	<string>https://github.com/Pyroh/Fluor</string>
 	<key>FLPyrolyseURL</key>

--- a/Fluor/Info.plist
+++ b/Fluor/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>2347</string>
+	<string>2371</string>
 	<key>FLGithubURL</key>
 	<string>https://github.com/Pyroh/Fluor</string>
 	<key>FLPyrolyseURL</key>


### PR DESCRIPTION
## Summary

- Fix build: remove empty scheme scripts, bump deployment target to macOS 11, migrate Sparkle to SPM
- Fix EXC_BAD_ACCESS crash when opening Rules Editor and Running Apps windows (KVO on `@objc let` properties)
- Update Sparkle storyboard bindings for v2 API
- Fix Rules Editor "-" (remove) button by binding table view selectionIndexes to NSArrayController
- Update SPM Package.resolved to v3 format

## Test plan

- [ ] Build with `xcodebuild -scheme Fluor -configuration Debug build`
- [ ] Launch app, open Rules Editor, add a rule, select it, click "-" — rule should be removed
- [ ] Open Rules Editor and Running Apps windows without crash
- [ ] Verify Preferences window opens and Sparkle update check works